### PR TITLE
do not do stuff for EFI on BIOS

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.1.8
+Version: 2.1.9
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.1.8";
+str VERSION = "2.1.9";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/system-installer/modules/verify_install.py
+++ b/usr/share/system-installer/modules/verify_install.py
@@ -114,17 +114,19 @@ def verify(username, root, distro):
         remove("/home/" + username + "/Desktop/system-installer.desktop")
     except FileNotFoundError:
         pass
-    status = is_default_entry(distro)
-    if status in (False, None):
-        if status is None:
-            add_boot_entry(root, distro)
-        set_default_entry(disto)
+    if path.isdir("/sys/firmware/efi"):
+        # on UEFI, set as default entry
+        status = is_default_entry(distro)
+        if status in (False, None):
+            if status is None:
+                add_boot_entry(root, distro)
+                set_default_entry(disto)
     cache = apt.cache.Cache()
     cache.open()
     if username != "drauger-user":
         if (("system-installer" in cache) and cache["system-installer"].is_installed):
             cache["system-installer"].mark_delete()
-        if path.isfile("/etc/kernel/postinst.d/zz-update-systemd-boot"):
+        if path.isdir("/sys/firmware/efi"):
             with cache.actiongroup():
                 for each in cache:
                     if (("grub" in each.name) and each.is_installed):


### PR DESCRIPTION
There were not checks in the verification script for if the user was 
using UEFI or BIOS, before trying to set efi vars. Added those checks 
in.