### PR TITLE
make sure root partition is big enough

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.2.5
+Version: 2.2.6
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.2.5";
+str VERSION = "2.2.6";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/system-installer/auto_partitioner.py
+++ b/usr/share/system-installer/auto_partitioner.py
@@ -580,7 +580,7 @@ Possible values:
     # it's elsewhere. We're good.
     if efi:
         part1 = __make_efi__(device)
-        part2 = __make_root__(device)
+        part2 = __make_root__(device, end="100%")
     else:
         part1 = __make_root__(device, start="0%", end="100%")
         __make_root_boot__(device)


### PR DESCRIPTION
On systems where the root drive is small, and EFI was in use, and a 
seperate /home partition was being used on a different drive, root 
partitions where not being made big enough. Fixed that.