### PR TITLE
minor code clean up and bug fix

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.2.8
+Version: 2.2.9
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.2.8";
+str VERSION = "2.2.9";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/system-installer/modules/master.py
+++ b/usr/share/system-installer/modules/master.py
@@ -292,12 +292,13 @@ def _install_grub(root):
 def _install_systemd_boot(release, root, distro):
     """set up and install systemd-boot"""
     try:
-        os.mkdir("/boot/efi")
+        os.makedirs("/boot/efi/loader/entries", exist_ok=True)
     except FileExistsError:
         pass
-    os.mkdir("/boot/efi/loader")
-    os.mkdir("/boot/efi/loader/entries")
-    os.mkdir(f"/boot/efi/{distro}")
+    try:
+        os.mkdir(f"/boot/efi/{distro}")
+    except FileExistsError:
+        pass
     os.environ["SYSTEMD_RELAX_ESP_CHECKS"] = "1"
     with open("/etc/environment", "a") as envi:
         envi.write("export SYSTEMD_RELAX_ESP_CHECKS=1")
@@ -309,11 +310,7 @@ def _install_systemd_boot(release, root, distro):
         eprint(e)
         eprint("Performing manual installation of systemd-boot.")
         try:
-            os.mkdir("/boot/efi/EFI")
-        except FileExistsError:
-            pass
-        try:
-            os.mkdir("/boot/efi/EFI/systemd")
+            os.makedirs("/boot/efi/EFI/systemd", exist_ok=True)
         except FileExistsError:
             pass
         try:


### PR DESCRIPTION
Instead of just calling `os.mkdir()` over and over in `try`/`except` 
blocks, make one call with the `exist_ok` flag set to `True` in order to 
set up the parent directories. Just make sure all `os.mkdir()` calls are 
in `try`/`catch` blocks.