### PR TITLE
boot-time improvments on EFI

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.2.9
+Version: 2.3.0
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/etc/system-installer/settings.json
+++ b/etc/system-installer/settings.json
@@ -15,10 +15,10 @@
 	"partitioning": {
 					"EFI": {
 							"START": 0,
-							"END": 200
+							"END": 500
 							},
 					"ROOT":{
-							"START": 201,
+							"START": 501,
 							"END": "40%",
 							"fs": "btrfs"
 							},

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.2.9";
+str VERSION = "2.3.0";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/system-installer/modules/verify_install.py
+++ b/usr/share/system-installer/modules/verify_install.py
@@ -29,7 +29,7 @@ from shutil import move
 import subprocess
 import apt
 
-import modules.purge as purge
+from modules import purge
 
 
 def __eprint__(*args, **kwargs):
@@ -47,9 +47,9 @@ def add_boot_entry(root, distro):
         part = root[8:]
 
     subprocess.check_call(["efibootmgr", "--create", "--disk", disk, "--part",
-                           part, "--loader", "\EFI\systemd\systemd-bootx64.efi",
-                           "--label", distro], stdout=stderr.buffer,
-                          stderr=stderr.buffer)
+                           part, "--loader",
+                           r"\EFI\systemd\systemd-bootx64.efi", "--label",
+                           distro], stdout=stderr.buffer, stderr=stderr.buffer)
 
 
 def set_default_entry(distro):
@@ -124,8 +124,9 @@ def verify(username, root, distro):
     cache = apt.cache.Cache()
     cache.open()
     if username != "drauger-user":
-        if (("system-installer" in cache) and cache["system-installer"].is_installed):
-            cache["system-installer"].mark_delete()
+        if "system-installer" in cache:
+            if cache["system-installer"].is_installed:
+                cache["system-installer"].mark_delete()
         if path.isdir("/sys/firmware/efi"):
             with cache.actiongroup():
                 for each in cache:

--- a/usr/share/system-installer/modules/verify_install.py
+++ b/usr/share/system-installer/modules/verify_install.py
@@ -130,7 +130,8 @@ def verify(username, root, distro):
             with cache.actiongroup():
                 for each in cache:
                     if (("grub" in each.name) and each.is_installed):
-                        each.mark_delete()
+                        if "common" not in each.name:
+                            each.mark_delete()
         cache.commit()
         purge.autoremove(cache)
     cache.close()


### PR DESCRIPTION
 * Increase default size of EFI partition to 500 MB to allow storage of more kernels and initramfs images.
 * Prevent `systemd-boot-manager` from being accidentally uninstalled