### PR TITLE
fix missing import, version bump

### DIFF
--- a/usr/share/system-installer/oem/pre_install.py
+++ b/usr/share/system-installer/oem/pre_install.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-#  main.py
+#  pre_install.py
 #
 #  Copyright 2022 Thomas Castleman <contact@draugeros.org>
 #
@@ -28,6 +28,7 @@ import re
 import json
 import os
 import subprocess
+import auto_partitioner
 import gi
 
 gi.require_version('Gtk', '3.0')


### PR DESCRIPTION
We need a version bump cause version 2.3.1 is already being used. So this fix includes a version bump