### PR TITLE
catch bug making swap file on BIOS

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.3.6
+Version: 2.3.7
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.3.6";
+str VERSION = "2.3.7";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/system-installer/modules/make_swap.py
+++ b/usr/share/system-installer/modules/make_swap.py
@@ -57,7 +57,12 @@ def make_swap():
     with open("/.swapfile", "w+") as swapfile:
         swapfile.write("")
         swapfile.flush()
-        subprocess.check_call(["chattr", "+C", "/.swapfile"])
+        try:
+            subprocess.check_call(["chattr", "+C", "/.swapfile"])
+        except subprocess.CalledProcessError:
+            # if this happens, we likely are not using a btrfs file system
+            # ignore
+            pass
         for i in range(loop_count):
             swapfile.write(master_string * (multiplyer * load_balancer))
             swapfile.flush()


### PR DESCRIPTION
This bug ONLY appears when:
 * making a SWAP file when autopartitioning on BIOS
 OR
 * making a SWAP file on an `ext4` file system, with either BIOS or UEFI

When making a SWAP file on `btrfs`, which is standard for UEFI when autopartitioning. We need to call:

```
chattr +C /.swapfile
```
in order to be allowed to use it. This command disables `btrfs`'s Copy-On-Write functionality for that one specific file. Unfortunately, it doesn't silently fail on `ext4` file systems. So, this PR adds a `try`/`except` block to handle that event. Thankfully, on `ext4` file systems, this command does not need to be run. So things should work out.