### PR TITLE
improve extras and updates installation

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.4.2
+Version: 2.4.3
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.4.1
+Version: 2.4.2
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.4.1";
+str VERSION = "2.4.2";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.4.2";
+str VERSION = "2.4.3";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/system-installer/UI/main.py
+++ b/usr/share/system-installer/UI/main.py
@@ -1636,18 +1636,18 @@ Type. Minimum drives is: %s""" % (loops))
         self.extras = self._set_default_margins(self.extras)
         self.grid.attach(self.extras, 1, 3, 2, 1)
 
-        label2 = Gtk.Label()
-        label2.set_markup("""
-        Update the system during installation""")
-        label2.set_justify(Gtk.Justification.LEFT)
-        label2 = self._set_default_margins(label2)
-        self.grid.attach(label2, 1, 4, 2, 1)
+        #  label2 = Gtk.Label()
+        #  label2.set_markup("""
+        #  Update the system during installation""")
+        #  label2.set_justify(Gtk.Justification.LEFT)
+        #  label2 = self._set_default_margins(label2)
+        #  self.grid.attach(label2, 1, 4, 2, 1)
 
-        self.updates = Gtk.CheckButton.new_with_label("Update before reboot")
-        if self.data["UPDATES"] == 1:
-            self.updates.set_active(True)
-        self.updates = self._set_default_margins(self.updates)
-        self.grid.attach(self.updates, 1, 5, 2, 1)
+        #  self.updates = Gtk.CheckButton.new_with_label("Update during Installation")
+        #  if self.data["UPDATES"] == 1:
+            #  self.updates.set_active(True)
+        #  self.updates = self._set_default_margins(self.updates)
+        #  self.grid.attach(self.updates, 1, 5, 2, 1)
 
         label2 = Gtk.Label()
         label2.set_markup("""
@@ -1680,10 +1680,10 @@ Type. Minimum drives is: %s""" % (loops))
             self.data["EXTRAS"] = 1
         else:
             self.data["EXTRAS"] = 0
-        if self.updates.get_active():
-            self.data["UPDATES"] = 1
-        else:
-            self.data["UPDATES"] = 0
+        #  if self.updates.get_active():
+            #  self.data["UPDATES"] = 1
+        #  else:
+        self.data["UPDATES"] = 0
         if self.login.get_active():
             self.data["LOGIN"] = 1
         else:
@@ -1838,6 +1838,8 @@ Sub-Region""")
             self.model_menu.append(model[each8], each8)
         if self.data["MODEL"] != "":
             self.model_menu.set_active_id(self.data["MODEL"])
+        else:
+            self.model_menu.set_active_id("pc105")
         self.model_menu = self._set_default_margins(self.model_menu)
         self.grid.attach(self.model_menu, 2, 2, 3, 1)
 

--- a/usr/share/system-installer/modules/install_extras.py
+++ b/usr/share/system-installer/modules/install_extras.py
@@ -53,47 +53,26 @@ def install_extras():
         # Newer cards take different drivers from older cards
         for each in ("BCM43142", "BCM4331", "BCM4360", "BCM4352"):
             if each in pci:
-                install_list = install_list + ["broadcom-sta-dkms", "dkms", "wireless-tools"]
+                install_list = install_list + ["broadcom-sta-dkms", "dkms",
+                                               "wireless-tools"]
                 break
         if len(install_list) == 2:
-            for each in ("BCM4311", "BCM4312", "BCM4313", "BCM4321", "BCM4322", "BCM43224", "BCM43225", "BCM43227", "BCM43228"):
+            for each in ("BCM4311", "BCM4312", "BCM4313", "BCM4321", "BCM4322",
+                         "BCM43224", "BCM43225", "BCM43227", "BCM43228"):
                 if each in pci:
-                    install_list = install_list.append("bcmwl-kernel-source")
+                    install_list.append("bcmwl-kernel-source")
                     break
     # Nvidia graphics cards
     if "nvidia" in pci.lower():
-        drivers = []
-        # We have other work we need to do after installing the Nvidia driver
-        NVIDIA = True
-        with cache.actiongroup():
-            for each in cache:
-                if "nvidia-driver-" in each.name:
-                    drivers.append(each.name)
-        for each in range(len(drivers) - 1, -1, -1):
-            try:
-                drivers[each] = int(drivers[each].split("-")[-1])
-            except ValueError:
-                pass
-        # Get the latest Nvidia driver
-        largest = drivers[0]
-        for each in drivers:
-            try:
-                if int(each) > largest:
-                    largest = each
-            except ValueError:
-                pass
-        install_list.append("nvidia-driver-" + str(largest))
+        # this isn't the ideal thing to do. Logic will be added later to handle
+        # installing drivers and `disable-nouveau` for older cards.
+        install_list.append("nvidia-driver-latest")
     # Install everything we want
     with cache.actiongroup():
         for each in install_list:
             cache[each].mark_install()
     cache.commit()
-    # Puge all the stuff we don't
+    # Purge all the stuff we don't want
     purge.purge_package("gstreamer1.0-fluendo-mp3")
     cache.close()
-    # Blacklist Nouveau if we installed the Nvidia drivers
-    if NVIDIA:
-        __eprint__("    ###    NVIDIA DRIVERS MAY HAVE BEEN INSTALLED. DISABLING NOUVEAU.    ###    ")
-        with open("/etc/modprobe.d/blacklist-nvidia-nouveau.conf", "w+") as blacklist:
-            blacklist.write("blacklist nouveau\noptions nouveau modeset=0\n")
     __eprint__("    ###    install_extras.py CLOSED    ###    ")

--- a/usr/share/system-installer/modules/install_updates.py
+++ b/usr/share/system-installer/modules/install_updates.py
@@ -44,7 +44,7 @@ def update_system():
     try:
         cache.upgrade(dist_upgrade=True)
     except apt.apt_pkg.Error:
-        print("ERROR: Possible held packages. Not performing update.")
+        print("ERROR: Possible held packages. Update may be partially completed.")
     cache.commit()
     purge.autoremove(cache)
     cache.close()

--- a/usr/share/system-installer/modules/install_updates.py
+++ b/usr/share/system-installer/modules/install_updates.py
@@ -41,7 +41,10 @@ def update_system():
     cache = apt.cache.Cache()
     cache.update()
     cache.open()
-    cache.upgrade(dist_upgrade=True)
+    try:
+        cache.upgrade(dist_upgrade=True)
+    except apt.apt_pkg.Error:
+        print("ERROR: Possible held packages. Not performing update.")
     cache.commit()
     purge.autoremove(cache)
     cache.close()


### PR DESCRIPTION
 * catch possible error due to held packages when installing updates
 * reduce the complexity of installing Nvidia drivers, due to the existance of `nvidia-driver-latest` and `disable-nouveau`
 * fix bug where no extras would be installed if needing Broadcom drivers
 * PEP8 improvements