### PR TITLE
update settings.json, fix Restricted Extras and Update during Install issues

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.5.2
+Version: 2.5.4
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: system-installer
-Version: 2.5.4
+Version: 2.5.5
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Homepage: https://github.com/drauger-os-development/system-installer
 Section: admin

--- a/build.conf
+++ b/build.conf
@@ -1,0 +1,9 @@
+# This file is for defining some simple build settings
+# start a line with a hashtag (#) to denote a comment
+#
+# ALL URLs should be rsync URLS
+#
+# META_URL contains the meta package for the kernel 
+META_URL=rsync://rsync.draugeros.org/apt/pool/main/l/linux-meta
+# PACK_URL contains the actual kernel image and header packages
+PACK_URL=rsync://rsync.draugeros.org/apt/pool/main/l/linux-upstream

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,9 @@ ARCH=$(cat DEBIAN/control | grep 'Architecture: '| sed 's/Architecture: //g')
 FOLDER="$PAK\_$VERSION\_$ARCH"
 FOLDER=$(echo "$FOLDER" | sed 's/\\//g')
 OPTIONS="$1"
+SETTINGS=$(grep -v "^#" build.conf | sed 's/=/ /g')
+META_URL=$(echo "$SETTINGS" | grep "META_URL" | awk '{print $2}')
+PACK_URL=$(echo "$SETTINGS" | grep "PACK_URL" | awk '{print $2}')
 mkdir ../"$FOLDER"
 ##############################################################
 #							     #
@@ -19,8 +22,8 @@ mkdir ../"$FOLDER"
 if [ "$OPTIONS" != "--pool" ]; then
 	cd usr/share/system-installer
 	echo -e "\t###\tDOWNLOADING\t###\t"
-	rsync -vr rsync://rsync.draugeros.org/apt/pool/main/l/linux-upstream kernel
-	rsync -vr rsync://rsync.draugeros.org/apt/pool/main/l/linux-meta kernel
+	rsync -vr "$PACK_URL" kernel
+	rsync -vr "$META_URL" kernel
 	echo -e "\t###\tDELETING CRUFT\t###\t"
 	list=$(ls kernel)
 	for each in $list; do
@@ -115,6 +118,8 @@ fi
 rm "$base"/usr/bin/system-installer
 # delete C++ source from package
 rm "$FOLDER"/usr/bin/system-installer.cxx
+# delete Python cache files
+find "$FOLDER" -maxdepth 10 -type d -name __pycache__ -exec rm -rfv {} \;
 #build the shit
 dpkg-deb --build "$FOLDER"
 rm -rf "$FOLDER"

--- a/etc/system-installer/settings.json
+++ b/etc/system-installer/settings.json
@@ -48,6 +48,8 @@
 						"mdswh": 128
 					}
 				},
-	"run_post_oem": ["/usr/share/drauger-welcome/main_ui.py"],
-	"kernel_meta_pkg": "linux-drauger"
+	"run_post_oem": ["/usr/bin/drauger-welcome"],
+	"kernel_meta_pkg": "linux-drauger",
+	"remove_pkgs": ["system-installer,
+			"persistence-daemon"]
 }

--- a/etc/system-installer/settings.json
+++ b/etc/system-installer/settings.json
@@ -50,6 +50,6 @@
 				},
 	"run_post_oem": ["/usr/bin/drauger-welcome"],
 	"kernel_meta_pkg": "linux-drauger",
-	"remove_pkgs": ["system-installer,
+	"remove_pkgs": ["system-installer",
 			"persistence-daemon"]
 }

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.5.4";
+str VERSION = "2.5.5";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/bin/system-installer.cxx
+++ b/usr/bin/system-installer.cxx
@@ -46,7 +46,7 @@
 
 using namespace std;
 
-str VERSION = "2.5.3";
+str VERSION = "2.5.4";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/share/system-installer/UI/main.py
+++ b/usr/share/system-installer/UI/main.py
@@ -1673,23 +1673,23 @@ Type. Minimum drives is: %s""" % (loops))
         self.grid.attach(label1, 1, 2, 2, 1)
 
         self.extras = Gtk.CheckButton.new_with_label("Install Restricted Extras")
-        if self.data["EXTRAS"] == 1:
+        if self.data["EXTRAS"]:
             self.extras.set_active(True)
         self.extras = self._set_default_margins(self.extras)
         self.grid.attach(self.extras, 1, 3, 2, 1)
 
-        #  label2 = Gtk.Label()
-        #  label2.set_markup("""
-        #  Update the system during installation""")
-        #  label2.set_justify(Gtk.Justification.LEFT)
-        #  label2 = self._set_default_margins(label2)
-        #  self.grid.attach(label2, 1, 4, 2, 1)
+        label2 = Gtk.Label()
+        label2.set_markup("""
+        Update the system during installation""")
+        label2.set_justify(Gtk.Justification.LEFT)
+        label2 = self._set_default_margins(label2)
+        self.grid.attach(label2, 1, 4, 2, 1)
 
-        #  self.updates = Gtk.CheckButton.new_with_label("Update during Installation")
-        #  if self.data["UPDATES"] == 1:
-            #  self.updates.set_active(True)
-        #  self.updates = self._set_default_margins(self.updates)
-        #  self.grid.attach(self.updates, 1, 5, 2, 1)
+        self.updates = Gtk.CheckButton.new_with_label("Update during Installation")
+        if self.data["UPDATES"]:
+            self.updates.set_active(True)
+        self.updates = self._set_default_margins(self.updates)
+        self.grid.attach(self.updates, 1, 5, 2, 1)
 
         label2 = Gtk.Label()
         label2.set_markup("""
@@ -1699,13 +1699,13 @@ Type. Minimum drives is: %s""" % (loops))
         self.grid.attach(label2, 1, 6, 2, 1)
 
         self.login = Gtk.CheckButton.new_with_label("Enable Auto-Login")
-        if self.data["LOGIN"] == 1:
+        if self.data["LOGIN"]:
             self.login.set_active(True)
         self.login = self._set_default_margins(self.login)
         self.grid.attach(self.login, 1, 7, 2, 1)
 
         self.compat_mode = Gtk.CheckButton.new_with_label("Enable Bootloader Compatibility Mode")
-        if self.data["COMPAT_MODE"] == 1:
+        if self.data["COMPAT_MODE"]:
             self.compat_mode.set_active(True)
         self.compat_mode = self._set_default_margins(self.compat_mode)
 
@@ -1735,8 +1735,7 @@ Type. Minimum drives is: %s""" % (loops))
     def options_next(self, button):
         """Set update and extras settings"""
         self.data["EXTRAS"] = self.extras.get_active()
-        #  self.data["UPDATES"] = self.updates.get_active()
-        self.data["UPDATES"] = False
+        self.data["UPDATES"] = self.updates.get_active()
         self.data["LOGIN"] = self.login.get_active()
         self.data["COMPAT_MODE"] = self.compat_mode.get_active()
         global OPTIONS_COMPLETION

--- a/usr/share/system-installer/common.py
+++ b/usr/share/system-installer/common.py
@@ -3,7 +3,7 @@
 #
 #  common.py
 #
-#  Copyright 2022 Thomas Castleman <contact@draugeros.org>
+#  Copyright 2023 Thomas Castleman <contact@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/usr/share/system-installer/modules/__init__.py
+++ b/usr/share/system-installer/modules/__init__.py
@@ -3,7 +3,7 @@
 #
 #  __init__.py
 #
-#  Copyright 2022 Thomas Castleman <contact@draugeros.org>
+#  Copyright 2023 Thomas Castleman <contact@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -32,3 +32,4 @@ import modules.set_wallpaper as set_wallpaper
 import modules.make_user as make_user
 import modules.purge as purge
 import modules.verify_install as verify_install
+import modules.common as common

--- a/usr/share/system-installer/modules/common.py
+++ b/usr/share/system-installer/modules/common.py
@@ -1,0 +1,1 @@
+../common.py

--- a/usr/share/system-installer/modules/install_updates.py
+++ b/usr/share/system-installer/modules/install_updates.py
@@ -3,7 +3,7 @@
 #
 #  install_updates.py
 #
-#  Copyright 2022 Thomas Castleman <contact@draugeros.org>
+#  Copyright 2023 Thomas Castleman <contact@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/usr/share/system-installer/modules/verify_install.py
+++ b/usr/share/system-installer/modules/verify_install.py
@@ -139,7 +139,7 @@ def verify(username, root, distro):
             for release in versions:
                 __eprint__(f"Generating Initramfs for Kernel v{ release }")
                 subproc.check_call(["mkinitramfs", "-o",
-                                   f"/boot/initramfs.img-{ release }",
+                                   f"/boot/initrd.img-{ release }",
                                    release])
             subproc.check_call(["update-systemd-boot"])
         cache.commit()

--- a/usr/share/system-installer/modules/verify_install.py
+++ b/usr/share/system-installer/modules/verify_install.py
@@ -3,7 +3,7 @@
 #
 #  verify_install.py
 #
-#  Copyright 2022 Thomas Castleman <contact@draugeros.org>
+#  Copyright 2023 Thomas Castleman <contact@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -24,11 +24,12 @@
 """Verify that installation completed correctly"""
 from __future__ import print_function
 from sys import stderr
-from os import path, remove
+import os
 from shutil import move
-import subprocess
+import subproc
 import apt
 import auto_partitioner
+import common
 
 from modules import purge
 
@@ -47,7 +48,7 @@ def add_boot_entry(root, distro):
         disk = root[:8]
         part = root[8:]
 
-    subprocess.check_call(["efibootmgr", "--create", "--disk", disk, "--part",
+    subproc.check_call(["efibootmgr", "--create", "--disk", disk, "--part",
                            part, "--loader",
                            r"\EFI\systemd\systemd-bootx64.efi", "--label",
                            distro], stdout=stderr.buffer, stderr=stderr.buffer)
@@ -55,7 +56,7 @@ def add_boot_entry(root, distro):
 
 def set_default_entry(distro):
     """Set default boot entry"""
-    entries = subprocess.check_output(["efibootmgr"]).decode().split("\n")
+    entries = subproc.check_output(["efibootmgr"]).decode().split("\n")
     entries = [each.split(" ") for each in entries]
     del entries[0]
     del entries[0]
@@ -76,12 +77,12 @@ def set_default_entry(distro):
     order = ",".join(entries[0][1])
     # clean up a bit
     del entries, code
-    subprocess.check_call(["efibootmgr", "-o", order])
+    subproc.check_call(["efibootmgr", "-o", order])
 
 
 def is_default_entry(distro):
     """Check if we are the default boot entry"""
-    entries = subprocess.check_output(["efibootmgr"]).decode().split("\n")
+    entries = subproc.check_output(["efibootmgr"]).decode().split("\n")
     entries = [each.split(" ") for each in entries]
     del entries[0]
     del entries[0]
@@ -109,10 +110,10 @@ def is_default_entry(distro):
 def verify(username, root, distro):
     """Verify installation success"""
     __eprint__("    ###    verify_install.py STARTED    ###    ")
-    if path.isdir("/home/home/live"):
+    if os.path.isdir("/home/home/live"):
         move("/home/home/live", "/home/" + username)
     try:
-        remove("/home/" + username + "/Desktop/system-installer.desktop")
+        os.remove("/home/" + username + "/Desktop/system-installer.desktop")
     except FileNotFoundError:
         pass
     if auto_partitioner.is_EFI():
@@ -134,6 +135,13 @@ def verify(username, root, distro):
                     if (("grub" in each.name) and each.is_installed):
                         if "common" not in each.name:
                             each.mark_delete()
+            versions = common.unique([each.split("-")[1] for each in os.listdir("/boot") if len(each.split("-")) > 1])
+            for release in versions:
+                __eprint__(f"Generating Initramfs for Kernel v{ release }")
+                subproc.check_call(["mkinitramfs", "-o",
+                                   f"/boot/initramfs.img-{ release }",
+                                   release])
+            subproc.check_call(["update-systemd-boot"])
         cache.commit()
         purge.autoremove(cache)
     cache.close()

--- a/usr/share/system-installer/modules/verify_install.py
+++ b/usr/share/system-installer/modules/verify_install.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 from sys import stderr
 import os
 from shutil import move
-import subproc
+import subprocess as subproc
 import apt
 import auto_partitioner
 import common

--- a/usr/share/system-installer/oem/post_install/UI.py
+++ b/usr/share/system-installer/oem/post_install/UI.py
@@ -115,6 +115,8 @@ class Main(Gtk.Window):
         global DEFAULT
         self.clear_window()
 
+        self.set_position(Gtk.WindowPosition.CENTER)
+
         label = Gtk.Label()
         label.set_markup(DEFAULT)
         label.set_justify(Gtk.Justification.LEFT)
@@ -133,6 +135,8 @@ class Main(Gtk.Window):
     def user(self, button):
         """User setup Window"""
         self.clear_window()
+
+        self.set_position(Gtk.WindowPosition.CENTER)
 
         label = Gtk.Label()
         label.set_markup("""
@@ -220,6 +224,8 @@ class Main(Gtk.Window):
     def locale(self, button):
         """Language and Time Zone settings menu"""
         self.clear_window()
+
+        self.set_position(Gtk.WindowPosition.CENTER)
 
         label = Gtk.Label()
         label.set_markup("""
@@ -330,6 +336,8 @@ Sub-Region""")
     def keyboard(self, button):
         """Keyboard Settings Dialog"""
         self.clear_window()
+
+        self.set_position(Gtk.WindowPosition.CENTER)
 
         label = Gtk.Label()
         label.set_markup("""

--- a/usr/share/system-installer/oem/pre_install.py
+++ b/usr/share/system-installer/oem/pre_install.py
@@ -3,7 +3,7 @@
 #
 #  pre_install.py
 #
-#  Copyright 2022 Thomas Castleman <contact@draugeros.org>
+#  Copyright 2023 Thomas Castleman <contact@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -86,6 +86,8 @@ class Main(Gtk.Window):
         """Auto Partitioning Settings Window"""
         self.clear_window()
 
+        self.set_position(Gtk.WindowPosition.CENTER)
+
         # Get a list of disks and their capacity
         self.devices = json.loads(subprocess.check_output(["lsblk", "-n", "-i", "--json",
                                                            "-o", "NAME,SIZE,TYPE,FSTYPE"]).decode())
@@ -166,6 +168,8 @@ class Main(Gtk.Window):
     def define_array(self, widget, error=None):
         """Define btrfs RAID Array settings"""
         self.clear_window()
+
+        self.set_position(Gtk.WindowPosition.CENTER)
 
         dev = []
         for each2 in enumerate(self.devices):
@@ -507,6 +511,8 @@ Type. Minimum drives is: %s""" % (loops))
     def exit(self, button):
         """Exit dialog"""
         self.clear_window()
+
+        self.set_position(Gtk.WindowPosition.CENTER)
 
         label = Gtk.Label()
         label.set_markup("""\n<b>Are you sure you want to exit?</b>


### PR DESCRIPTION
This update fixes 2 major issues, and a couple minor ones too:

- Enabling Restricted Extras causing a fresh install to fail to an `initramfs` shell has been fixed
- Enabling Updates during Installation causing a fresh install to fail to an `initramfs` shell has been fixed
- post-OEM install completion, `drauger-welcome` should now display

There have also been minor logic improvements and updates to copyright years in some files.