### PR TITLE
Various bug fixes

### DIFF
--- a/DEBIAN/edamame-common.control
+++ b/DEBIAN/edamame-common.control
@@ -1,5 +1,5 @@
 Package: edamame-common
-Version: 3.1.7
+Version: 3.1.8
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-common.control
+++ b/DEBIAN/edamame-common.control
@@ -1,5 +1,5 @@
 Package: edamame-common
-Version: 3.1.4
+Version: 3.1.5
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-common.control
+++ b/DEBIAN/edamame-common.control
@@ -1,5 +1,5 @@
 Package: edamame-common
-Version: 3.1.5
+Version: 3.1.6
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-common.control
+++ b/DEBIAN/edamame-common.control
@@ -1,5 +1,5 @@
 Package: edamame-common
-Version: 3.1.6
+Version: 3.1.7
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-gtk.control
+++ b/DEBIAN/edamame-gtk.control
@@ -1,5 +1,5 @@
 Package: edamame-gtk
-Version: 2.9.6
+Version: 2.9.7
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-qt.control
+++ b/DEBIAN/edamame-qt.control
@@ -1,5 +1,5 @@
 Package: edamame-qt
-Version: 3.0.2
+Version: 3.0.3
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-qt.control
+++ b/DEBIAN/edamame-qt.control
@@ -1,5 +1,5 @@
 Package: edamame-qt
-Version: 3.0.5
+Version: 3.0.6
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-qt.control
+++ b/DEBIAN/edamame-qt.control
@@ -1,5 +1,5 @@
 Package: edamame-qt
-Version: 3.0.3
+Version: 3.0.4a
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-qt.control
+++ b/DEBIAN/edamame-qt.control
@@ -1,5 +1,5 @@
 Package: edamame-qt
-Version: 3.0.6
+Version: 3.0.7
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/DEBIAN/edamame-qt.control
+++ b/DEBIAN/edamame-qt.control
@@ -1,5 +1,5 @@
 Package: edamame-qt
-Version: 3.0.4a
+Version: 3.0.5
 Maintainer: Thomas Castleman <batcastle@draugeros.org>
 Homepage: https://github.com/drauger-os-development/edamame
 Section: admin

--- a/etc/edamame/settings.json
+++ b/etc/edamame/settings.json
@@ -51,7 +51,7 @@
 				},
 	"run_post_oem": ["/usr/bin/drauger-welcome"],
 	"kernel_meta_pkg": "linux-drauger",
-	"remove_pkgs": ["edamame",
+	"remove_pkgs": ["edamame-common",
 					"persistence-daemon"],
 	"hostname_prepend": "DRAUGER",
 	"hostname_append_len": 8,

--- a/quick-install-spec.md
+++ b/quick-install-spec.md
@@ -1,0 +1,284 @@
+# Quick Install File Format Specification
+
+**Version:** 2.1
+**Status:** Draft
+**Maintainer:** Thomas Castleman \<batcastle@draugeros.org\>
+
+---
+
+## Overview
+
+A Quick Install file captures system configuration so that an installer
+(such as Edamame) can reproduce that configuration on a fresh installation
+with minimal user interaction. It is designed to be simple enough that a
+technically literate user can write one by hand in under 15 minutes without
+any tooling.
+
+Quick Install files come in two formats depending on whether carry-over
+assets (network profiles, wallpaper) are included:
+
+| Situation | Format | Extension | Name |
+|---|---|---|---|
+| Settings only | JSON text file | `.json` | Quick Install File |
+| Settings + assets | XZ-compressed tar archive | `.tar.xz` | Advanced Quick Install File |
+
+---
+
+## JSON Format
+
+### Top-level structure
+
+The JSON file may be structured in one of two equivalent ways.
+
+**With a `DATA` wrapper** (recommended for human-authored files):
+
+```json
+{
+    "DATA": {
+        "LANG": "en",
+        ...
+    },
+    "COMMENTS": [
+        "Any comments go here as an array of strings.",
+        "This field is entirely optional and ignored by all tooling."
+    ]
+}
+```
+
+**Flat structure** (produced by Edamame's built-in export):
+
+```json
+{
+    "LANG": "en",
+    ...
+}
+```
+
+Both are valid. When a `DATA` key is present, all tooling discards the
+rest of the top-level object and reads only `DATA`. The `COMMENTS` field
+is always ignored by tooling and exists solely for human readers.
+
+---
+
+### Fields
+
+All fields listed below live either directly at the top level (flat
+format) or inside `DATA` (wrapped format).
+
+#### Partitioning
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `AUTO_PART` | `bool` | Yes | If `true`, the installer partitions the target drive automatically. All partition fields below are ignored when this is `true`. |
+| `ROOT` | `string \| null` | Yes | Device path for the root (`/`) partition. e.g. `/dev/sda2`. `null` when `AUTO_PART` is `true`. |
+| `EFI` | `string \| null` | Yes | Device path for the EFI System Partition. e.g. `/dev/sda1`. `null` on BIOS systems or when `AUTO_PART` is `true`. Treated as absent when set to `"NULL"`, `""`, or `false`. |
+| `HOME` | `string \| null` | Yes | Device path for a separate `/home` partition. `null` if no separate home partition is desired. Treated as absent when set to `"NULL"` or `""`. The special value `"MAKE"` (only valid when `AUTO_PART` is `true`) instructs the auto-partitioner to create a dedicated home partition on the same target drive. |
+| `SWAP` | `string \| null` | Yes | Device path for a swap partition (e.g. `/dev/sda3`), or the special string `"FILE"` to instruct the installer to create a swap file on the root partition. When `"FILE"` is used the installer is responsible for computing the swap file size using the formula recommended by the Linux kernel developers: `SWAP_SIZE = RAM_SIZE + √RAM_SIZE`. This size enables both full suspend and Hybrid Sleep. `null` if no swap is desired. **Note:** Edamame always sets this field to either `"FILE"` or a device path — it requires some form of swap for system stability and will not generate a Quick Install file with `null` here. Setting `SWAP` to `null` in a hand-authored file may bypass this, but correct behaviour with Edamame is not guaranteed. Other installers are encouraged to follow the same convention and require swap for consistency. |
+
+**Note on BTRFS RAID home partitions:** When a home partition lives on a
+drive formatted entirely with BTRFS as part of a RAID array (i.e. no
+partition table), `HOME` may be set to a bare drive path such as
+`/dev/sdb`. This is the only situation where a bare drive path is valid
+for any partition field.
+
+#### RAID Array
+
+The `raid_array` field is an object with the following structure:
+
+```json
+"raid_array": {
+    "raid_type": null,
+    "disks": {
+        "1": null,
+        "2": null,
+        "3": null,
+        "4": null
+    }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `raid_type` | `string \| null` | RAID level as a string: `"0"`, `"1"`, or `"10"`. These are the only levels supported, as they are the only RAID modes BTRFS supports. `null` if RAID is not in use. |
+| `disks` | `object` | Object with string integer keys (starting from `"1"`) mapping to device path strings. A minimum of two disks must be defined. RAID 0 and RAID 1 require at least 2 disks; RAID 10 requires at least 4. The list may be longer than 4 entries if the array spans more drives. Unused slots should be set to `null`. The default template provides 4 slots to encourage RAID 10 for its balance of speed and redundancy. |
+
+#### Locale and Input
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `LANG` | `string` | Yes | Two-letter ISO 639-1 language code. e.g. `"en"`, `"fr"`, `"de"`. |
+| `TIME_ZONE` | `string` | Yes | IANA timezone string in `Region/SubRegion` format. e.g. `"US/Eastern"`, `"Europe/London"`. |
+| `LAYOUT` | `string` | Yes | Human-readable keyboard layout label. e.g. `"English(US)"`. |
+| `VARIENT` | `string` | Yes | Human-readable keyboard variant label. e.g. `"English(US) - English(US, euro on 5)"`. Note: this key is intentionally spelled `VARIENT` (not `VARIANT`) for historical compatibility. |
+| `MODEL` | `string` | Yes | Keyboard model identifier. e.g. `"pc105"`, `"pc104"`. |
+
+#### User Account
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `USERNAME` | `string` | Yes | Username for the primary user account created during installation. |
+| `PASSWORD` | `string` | Yes | Plaintext password for the primary user account. **This value is not encrypted or hashed. Do not share this file without removing this field.** |
+| `COMPUTER_NAME` | `string` | Yes | Hostname for the installed system. |
+
+#### Installation Behaviour
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `EXTRAS` | `bool` | Yes | If `true`, install restricted extras during setup: proprietary media codecs (MP3, AAC, H.264) and proprietary GPU drivers (NVIDIA, AMD). |
+| `UPDATES` | `bool` | Yes | If `true`, run a full system update as part of the installation process. |
+| `LOGIN` | `bool` | Yes | If `true`, enable automatic login for the primary user at boot. |
+| `COMPAT_MODE` | `bool` | No | Bootloader Compatibility Mode. If `true`, installs systemd-boot in its standard EFI location and additionally places the bootloader at the Windows Boot Manager path (`EFI/Microsoft/Boot/bootmgfw.efi`), allowing Linux to boot on locked-down UEFI firmware that only permits the Windows bootloader. Defaults to `false` if absent (for backwards compatibility with older files). |
+
+#### OEM Mode
+
+If any field value is the string `"OEM"`, the installer treats this as
+an OEM pre-configuration installation. In this mode, certain steps are
+skipped during the initial install and handled later when the end user
+first boots the machine. Tooling that generates Quick Install files for
+end users should not set any field to `"OEM"`.
+
+---
+
+### Minimal valid example
+
+```json
+{
+    "DATA": {
+        "LANG": "en",
+        "TIME_ZONE": "US/Eastern",
+        "AUTO_PART": true,
+        "ROOT": null,
+        "EFI": null,
+        "HOME": null,
+        "SWAP": null,
+        "USERNAME": "alice",
+        "PASSWORD": "changeme",
+        "COMPUTER_NAME": "my-computer",
+        "EXTRAS": true,
+        "UPDATES": false,
+        "LOGIN": false,
+        "COMPAT_MODE": false,
+        "MODEL": "pc105",
+        "LAYOUT": "English(US)",
+        "VARIENT": "English(US) - English(US, euro on 5)",
+        "raid_array": {
+            "raid_type": null,
+            "disks": {
+                "1": null,
+                "2": null,
+                "3": null,
+                "4": null
+            }
+        }
+    },
+    "COMMENTS": [
+        "Remove or leave the COMMENTS field as you prefer.",
+        "Remember to remove the PASSWORD field before sharing this file."
+    ]
+}
+```
+
+---
+
+## Advanced Quick Install File Format (`.tar.xz`)
+
+When network settings or wallpaper are to be carried over, the Quick
+Install file becomes an XZ-compressed tar archive. The JSON settings file
+lives inside the archive alongside any assets.
+
+### Directory structure
+
+```
+<archive>.tar.xz
+├── settings/
+│   ├── installation-settings.json   ← the JSON config described above
+│   ├── network-settings/            ← NetworkManager connection profiles
+│   │   └── <profile-name>           ← one file per saved connection
+│   └── network-settings-NP/         ← netplan configuration
+│       └── *.yaml
+└── assets/
+    ├── screens.list                  ← present only with a single wallpaper
+    └── master/                       ← single wallpaper (all monitors)
+        └── wallpaper.<ext>
+```
+
+**Multi-monitor wallpaper variant:** when different monitors use different
+wallpapers, `assets/master/` is absent and each monitor gets its own
+directory instead:
+
+```
+assets/
+└── <monitor-name>/
+    └── wallpaper.<ext>
+```
+
+In this case `screens.list` is not present, and the directory name
+corresponds to the monitor identifier as reported by the desktop
+environment.
+
+### Field details
+
+#### `settings/installation-settings.json`
+
+The full Quick Install JSON config as described above. Either the flat or
+`DATA`-wrapped format is valid here.
+
+#### `settings/network-settings/`
+
+Contains NetworkManager system connection profile files copied verbatim
+from `/etc/NetworkManager/system-connections/` on the source machine.
+These are applied to the live environment during installation, before
+the network is used to download packages.
+
+May be absent if network carry-over was not selected.
+
+#### `settings/network-settings-NP/`
+
+Contains netplan configuration files (`.yaml`) copied from `/etc/netplan/`
+on the source machine. On systems not using netplan, this directory will
+be absent or empty, and the installer silently ignores it.
+
+On Windows source machines, this directory may contain synthesized netplan
+files generated from the Windows network configuration.
+
+May be absent if network carry-over was not selected.
+
+#### `assets/master/wallpaper.<ext>`
+
+The desktop wallpaper image. The file extension is preserved from the
+original file. Any image format the target desktop environment supports is
+valid here. The installer does not validate the format — it copies the
+file to `/user-data/wallpaper.<ext>` on the new installation for the
+post-install setup to consume.
+
+On Windows source machines where the wallpaper is sourced from the
+`TranscodedWallpaper` cache (which has no extension), `.jpg` is assumed
+since Windows always transcodes wallpapers to JPEG in that cache location.
+
+#### `assets/screens.list`
+
+Plain text file, one monitor identifier per line, listing which monitors
+should use the `master` wallpaper. Present only alongside `assets/master/`.
+
+#### `assets/<monitor-name>/wallpaper.<ext>`
+
+Per-monitor wallpaper, used when different monitors have different
+wallpapers. The directory name is the monitor identifier as reported by
+the desktop environment on the source machine.
+
+---
+
+## Backwards Compatibility
+
+- **`COMPAT_MODE` absent:** treated as `false`. Files generated before
+  this field was introduced continue to work without modification.
+- **Flat vs. wrapped JSON:** both have been valid since the format's
+  introduction. Do not rely on the presence of `DATA` to detect file
+  version.
+- **`EFI`, `HOME` set to `"NULL"`, `""`, or `false`:** all treated
+  identically to `null` by the installer for historical reasons. New
+  files should use `null`.
+
+---
+
+

--- a/usr/bin/edamame.cxx
+++ b/usr/bin/edamame.cxx
@@ -1,7 +1,7 @@
 /*
  * edamame.cxx
  *
- * Copyright 2025 Thomas Castleman <batcastle@draugeros.org>
+ * Copyright 2026 Thomas Castleman <batcastle@draugeros.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,7 +36,7 @@
 
 using namespace std;
 
-str VERSION = "3.1.5";
+str VERSION = "3.1.6";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";

--- a/usr/bin/edamame.cxx
+++ b/usr/bin/edamame.cxx
@@ -36,7 +36,7 @@
 
 using namespace std;
 
-str VERSION = "3.1.1";
+str VERSION = "3.1.5";
 str R = "\033[0;31m";
 str G = "\033[0;32m";
 str Y = "\033[1;33m";
@@ -44,7 +44,7 @@ str NC = "\033[0m";
 str HELP = "\n"
 "Edamame, Version " + VERSION + "\n"
 "\n"
-"\t    --gui               specify the GUI to use. May throw an error if given toolkit is not available."
+"\t    --gui               specify the GUI to use. May throw an error if given toolkit is not available.\n"
 "\t-h, --help              print this help dialoge.\n"
 "\t    --boot-time         launch Edamame in boot-time mode.\n"
 "\t-v, --version           print current version.\n"

--- a/usr/share/edamame/UI/GTK_UI/success.py
+++ b/usr/share/edamame/UI/GTK_UI/success.py
@@ -385,6 +385,8 @@ def adv_dump_settings(settings, dump_path, copy_net=True, copy_set=True,
                                   shell=True)
             copytree("/etc/NetworkManager/system-connections",
                      "/tmp/working_dir/settings/network-settings")
+            copytree("/etc/netplan",
+                     "/tmp/working_dir/settings/network-settings-NP")
             subprocess.check_call("echo 'toor' | sudo -S chmod 600 " + net_connections + "/*",
                                   shell=True)
     if copy_wall:

--- a/usr/share/edamame/UI/QT_UI/main.py
+++ b/usr/share/edamame/UI/QT_UI/main.py
@@ -1727,16 +1727,17 @@ size will be generated for you.""")
                 pass
             self.grid.addWidget(label, 1, 1, 1, 3)
             return
-        if ap.size_of_part(efi) < ap.get_min_efi_size():
-            label_string = \
+        if ap.is_EFI()
+            if ap.size_of_part(efi) < ap.get_min_efi_size():
+                label_string = \
         f"""EFI Partition is too small. Minimum EFI Partition size is { ap.get_min_efi_size() } MB"""
-            label = self.set_up_partitioner_label(label_string)
-            try:
-                self.grid.itemAtPosition(1, 1).widget().setParent(None)
-            except (TypeError, AttributeError):
-                pass
-            self.grid.addWidget(label, 1, 1, 1, 3)
-            return
+                label = self.set_up_partitioner_label(label_string)
+                try:
+                    self.grid.itemAtPosition(1, 1).widget().setParent(None)
+                except (TypeError, AttributeError):
+                    pass
+                self.grid.addWidget(label, 1, 1, 1, 3)
+                return
         if ((swap.upper() == "FILE") or (swap == "")):
             if ap.size_of_part(self.root_parts.currentText()) < ap.get_min_root_size(bytes=False):
                 label_string = \

--- a/usr/share/edamame/UI/QT_UI/main.py
+++ b/usr/share/edamame/UI/QT_UI/main.py
@@ -1727,7 +1727,7 @@ size will be generated for you.""")
                 pass
             self.grid.addWidget(label, 1, 1, 1, 3)
             return
-        if ap.is_EFI()
+        if ap.is_EFI():
             if ap.size_of_part(efi) < ap.get_min_efi_size():
                 label_string = \
         f"""EFI Partition is too small. Minimum EFI Partition size is { ap.get_min_efi_size() } MB"""

--- a/usr/share/edamame/UI/QT_UI/progress.py
+++ b/usr/share/edamame/UI/QT_UI/progress.py
@@ -3,7 +3,7 @@
 #
 #  progress.py
 #
-#  Copyright 2025 Thomas Castleman <batcastle@draugeros.org>
+#  Copyright 2026 Thomas Castleman <batcastle@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -143,7 +143,7 @@ def show_progress():
     signal.signal(signal.SIGTERM, handle_sig_term)
     app = QtWidgets.QApplication([sys.argv[0]])
     global window
-    window = Main(distro)
+    window = Main(app, distro=distro)
     window = QCommon.set_window_undecorated(window)
     window = QCommon.set_window_nonresizeable(window)
     window.show()

--- a/usr/share/edamame/UI/QT_UI/success.py
+++ b/usr/share/edamame/UI/QT_UI/success.py
@@ -312,6 +312,8 @@ def adv_dump_settings(settings, dump_path, copy_net=True, copy_set=True,
                                   shell=True)
             copytree("/etc/NetworkManager/system-connections",
                      "/tmp/working_dir/settings/network-settings")
+            copytree("/etc/netplan",
+                     "/tmp/working_dir/settings/network-settings-NP")
             subprocess.check_call("echo 'toor' | sudo -S chmod 600 " + net_connections + "/*",
                                   shell=True)
     if copy_wall:
@@ -340,7 +342,7 @@ def adv_dump_settings(settings, dump_path, copy_net=True, copy_set=True,
                 os.mkdir("/tmp/working_dir/assets/master")
             except FileExistsError:
                 pass
-            with open("/tmp/working_dir/assets/screens.list", w) as screens_list:
+            with open("/tmp/working_dir/assets/screens.list", "w") as screens_list:
                 for each in monitors:
                     screens_list.write(each + "\n")
             file_type = wall_path[0].split("/")[-1].split(".")[-1]

--- a/usr/share/edamame/engine.py
+++ b/usr/share/edamame/engine.py
@@ -178,10 +178,18 @@ try:
                 shutdown(BOOT_TIME, immerse, 2)
             try:
                 net_settings = os.listdir(work_dir + "/settings/network-settings")
+                net_settings1 = os.listdir(work_dir + "/settings/network-settings-NP")
                 if len(net_settings) > 0:
                     shutil.copytree(net_settings + "/settings/network-settings",
                                     "/etc/NetworkManager/system-connections")
-                    common.eprint("\t###\tNOTE: NETWORK SETTINGS COPIED TO LIVE SYSTEM\t###\t")
+                    common.eprint("\t###\tNOTE: NETWORK SETTINGS (from NetworkManager) COPIED TO LIVE SYSTEM\t###\t")
+                if len(net_settings1 > 0:
+                    try:
+                        shutil.copytree(net_settings + "/settings/network-settings-NP",
+                                        "/etc/netplan")
+                        common.eprint("\t###\tNOTE: NETWORK SETTINGS (from Netplan.io) COPIED TO LIVE SYSTEM\t###\t")
+                    except FileNotFoundError:
+                        common.eprint("NOTICE: SYSTEM NOT USING NETPLAN.IO")
             except FileNotFoundError:
                 pass
         if "DATA" in SETTINGS:

--- a/usr/share/edamame/engine.py
+++ b/usr/share/edamame/engine.py
@@ -177,15 +177,13 @@ try:
 """)
                 shutdown(BOOT_TIME, immerse, 2)
             try:
-                net_settings = os.listdir(work_dir + "/settings/network-settings")
-                net_settings1 = os.listdir(work_dir + "/settings/network-settings-NP")
-                if len(net_settings) > 0:
-                    shutil.copytree(net_settings + "/settings/network-settings",
+                if len(os.listdir(work_dir + "/settings/network-settings")) > 0:
+                    shutil.copytree(work_dir + "/settings/network-settings",
                                     "/etc/NetworkManager/system-connections")
                     common.eprint("\t###\tNOTE: NETWORK SETTINGS (from NetworkManager) COPIED TO LIVE SYSTEM\t###\t")
-                if len(net_settings1) > 0:
+                if len(os.listdir(work_dir + "/settings/network-settings-NP")) > 0:
                     try:
-                        shutil.copytree(net_settings1 + "/settings/network-settings-NP",
+                        shutil.copytree(work_dir + "/settings/network-settings-NP",
                                         "/etc/netplan")
                         common.eprint("\t###\tNOTE: NETWORK SETTINGS (from Netplan.io) COPIED TO LIVE SYSTEM\t###\t")
                     except FileNotFoundError:

--- a/usr/share/edamame/engine.py
+++ b/usr/share/edamame/engine.py
@@ -3,7 +3,7 @@
 #
 #  engine.py
 #
-#  Copyright 2025 Thomas Castleman <batcastle@draugeros.org>
+#  Copyright 2026 Thomas Castleman <batcastle@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -183,9 +183,9 @@ try:
                     shutil.copytree(net_settings + "/settings/network-settings",
                                     "/etc/NetworkManager/system-connections")
                     common.eprint("\t###\tNOTE: NETWORK SETTINGS (from NetworkManager) COPIED TO LIVE SYSTEM\t###\t")
-                if len(net_settings1 > 0:
+                if len(net_settings1) > 0:
                     try:
-                        shutil.copytree(net_settings + "/settings/network-settings-NP",
+                        shutil.copytree(net_settings1 + "/settings/network-settings-NP",
                                         "/etc/netplan")
                         common.eprint("\t###\tNOTE: NETWORK SETTINGS (from Netplan.io) COPIED TO LIVE SYSTEM\t###\t")
                     except FileNotFoundError:

--- a/usr/share/edamame/installer.py
+++ b/usr/share/edamame/installer.py
@@ -247,6 +247,12 @@ def install(settings: dict, local_repo: str, ui_type: str) -> None:
     shutil.rmtree("/mnt/etc/NetworkManager/system-connections")
     shutil.copytree("/etc/NetworkManager/system-connections",
                     "/mnt/etc/NetworkManager/system-connections")
+    try:
+        shutil.rmtree("/mnt/etc/netplan")
+        shutil.copytree("/etc/netplan",
+                        "/mnt/etc/netplan")
+    except FileNotFoundError:
+        common.eprint("NOTICE: SYSTEM NOT USING NETPLAN.IO")
     if os.path.exists(work_dir) and os.path.exists(work_dir + "/assets"):
         ls = os.listdir(work_dir + "/assets")
         os.mkdir("/mnt/user-data")

--- a/usr/share/edamame/modules/master.py
+++ b/usr/share/edamame/modules/master.py
@@ -79,7 +79,7 @@ class MainInstallation():
         # to change, so re-doing the math is safer, albiet slower.
         self.point = round(ending / len(self.processes_to_do))
 
-    def parallel_install(self):
+    def _parallel_install(self):
         """Install Drauger OS, using multi-processing. The idea is to get everything done as quick as possible."""
 
         # while len(processes_to_do) > 0:
@@ -143,7 +143,7 @@ class MainInstallation():
             # This line is temporary, for debugging purposes.
             # eprint(f"Running Processes: {len(working)}\nProcesses to do: {len(processes_to_do) - len(working)}")
 
-    def sequental_install(self):
+    def _sequental_install(self):
         """Install Drauger OS, but instead of the multi-threaded approach above, do everything sequentially"""
         for each in self.processes_to_do:
             process_new = getattr(MainInstallation, each, self)
@@ -655,12 +655,12 @@ def install(settings, distro):
     installer = MainInstallation(processes_to_do, settings)
     if os.cpu_count() > 2:
         try:
-            installer.parallel_install()
+            installer._parallel_install()
         except ConnectionResetError:
             eprint("WARNING: IT APPEARS MULTI-THREADED INSTALLATION FAILED. REATTEMPTING SEQUENTIALLY...")
-            installer.sequental_install()
+            installer._sequental_install()
     else:
-        installer.sequental_install()
+        installer._sequental_install()
     handle_laptops(settings["USERNAME"])
     setup_lowlevel(settings["EFI"], settings["ROOT"], distro,
                    settings["COMPAT_MODE"], settings["UPDATES"])

--- a/usr/share/edamame/modules/master.py
+++ b/usr/share/edamame/modules/master.py
@@ -3,7 +3,7 @@
 #
 #  master.py
 #
-#  Copyright 2025 Thomas Castleman <batcastle@draugeros.org>
+#  Copyright 2026 Thomas Castleman <batcastle@draugeros.org>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -69,15 +69,7 @@ def __update__(percentage):
 class MainInstallation():
     """Main Installation Procedure, minus low-level stuff"""
     def __init__(self, processes_to_do, settings):
-        # for each1 in processes_to_do:
-        #     process_new = getattr(MainInstallation, each1, self)
-        #     args_list = getfullargspec(process_new)[0]
-        #     args = []
-        #     for each in args_list:
-        #         args.append(settings[each])
-        #     globals()[each1] = multiprocessing.Process(target=process_new,
-        #                                                args=args)
-        #     globals()[each1].start()
+        """Install Drauger OS, using multi-processing. The idea is to get everything done as quick as possible."""
         offset = 39
         ending = 51
         iterator = round(ending / len(processes_to_do))
@@ -145,6 +137,18 @@ class MainInstallation():
             # This line is temporary, for debugging purposes.
             # eprint(f"Running Processes: {len(working)}\nProcesses to do: {len(processes_to_do) - len(working)}")
 
+    def sequental_install(processes_to_do, settings):
+        """Install Drauger OS, but instead of the multi-threaded approach above, do everything sequentially"""
+        for each in processes_to_do:
+            process_new = getattr(MainInstallation, new, self)
+            args_list = getfullargspec(process_new)[0]
+            args = []
+            for each in args_list:
+                args.append(settings[each])
+            # Not sure if this works. Keep an eye on it.
+            process_new(*args)
+            __update__(point + offset)
+            point += iterator
 
     def time_set(TIME_ZONE):
         """Set system time"""
@@ -642,7 +646,14 @@ def install(settings, distro):
     for each in range(len(processes_to_do) - 1, -1, -1):
         if processes_to_do[each][0] == "_":
             del processes_to_do[each]
-    MainInstallation(processes_to_do, settings)
+    if os.cpu_count() > 2:
+        try:
+            MainInstallation(processes_to_do, settings)
+        except ConnectionResetError:
+            eprint("WARNING: IT APPEARS MULTI-THREADED INSTALLATION FAILED. REATTEMPTING SEQUENTIALLY...")
+            MainInstallation.sequental_install(processes_to_do, settings)
+    else:
+        MainInstallation.sequental_install(processes_to_do, settings)
     handle_laptops(settings["USERNAME"])
     setup_lowlevel(settings["EFI"], settings["ROOT"], distro,
                    settings["COMPAT_MODE"], settings["UPDATES"])

--- a/usr/share/edamame/modules/master.py
+++ b/usr/share/edamame/modules/master.py
@@ -137,7 +137,7 @@ class MainInstallation():
             # This line is temporary, for debugging purposes.
             # eprint(f"Running Processes: {len(working)}\nProcesses to do: {len(processes_to_do) - len(working)}")
 
-    def sequental_install(processes_to_do, settings):
+    def sequental_install(self, processes_to_do, settings):
         """Install Drauger OS, but instead of the multi-threaded approach above, do everything sequentially"""
         for each in processes_to_do:
             process_new = getattr(MainInstallation, each, self)

--- a/usr/share/edamame/modules/master.py
+++ b/usr/share/edamame/modules/master.py
@@ -140,7 +140,7 @@ class MainInstallation():
     def sequental_install(processes_to_do, settings):
         """Install Drauger OS, but instead of the multi-threaded approach above, do everything sequentially"""
         for each in processes_to_do:
-            process_new = getattr(MainInstallation, new, self)
+            process_new = getattr(MainInstallation, each, self)
             args_list = getfullargspec(process_new)[0]
             args = []
             for each in args_list:

--- a/usr/share/edamame/modules/master.py
+++ b/usr/share/edamame/modules/master.py
@@ -69,13 +69,18 @@ def __update__(percentage):
 class MainInstallation():
     """Main Installation Procedure, minus low-level stuff"""
     def __init__(self, processes_to_do, settings):
+        """Basic setup process"""
+        self.processes_to_do = processes_to_do
+        self.settings = settings
+
+    def parallel_install(self):
         """Install Drauger OS, using multi-processing. The idea is to get everything done as quick as possible."""
         offset = 39
         ending = 51
-        iterator = round(ending / len(processes_to_do))
+        iterator = round(ending / len(self.processes_to_do))
         # We COULD set point equal to iterator, but we don't want the iterator
         # to change, so re-doing the math is safer, albiet slower.
-        point = round(ending / len(processes_to_do))
+        point = round(ending / len(self.processes_to_do))
         # while len(processes_to_do) > 0:
         #     for each in range(len(processes_to_do) - 1, -1, -1):
         #         if not globals()[processes_to_do[each]].is_alive():
@@ -90,14 +95,14 @@ class MainInstallation():
         This new spawner is designed to scale with how many cores a given CPU has, so we don't over extend our resources
         """
         working = {}
-        while len(processes_to_do) > 0:
+        while len(self.processes_to_do) > 0:
             # First, check if we have any processes that are completed that we need to close
             to_del = []
             for each in working:
                 if not working[each].is_alive():
                     # We have a process to clean up
                     working[each].join()
-                    del processes_to_do[processes_to_do.index(each)]
+                    del self.processes_to_do[self.processes_to_do.index(each)]
                     to_del.append(each)
                     __update__(point + offset)
                     point += iterator
@@ -109,13 +114,13 @@ class MainInstallation():
             # but it will also leave more resources so the computer does not push itself TOO hard.
             if len(working) < (os.cpu_count() - 1):
                 # We have fewer processes than CPUs.
-                if len(processes_to_do) > len(working):
+                if len(self.processes_to_do) > len(working):
                     """
                         Processes that are spawned remain in the "to-do" list until done.
                         So, the to-do list is always greater than or equal in length to the list of currently running processes
                     """
                     new = None
-                    for each in processes_to_do:
+                    for each in self.processes_to_do:
                         if each not in working.keys():
                             new = each
                             break
@@ -125,7 +130,7 @@ class MainInstallation():
                     args_list = getfullargspec(process_new)[0]
                     args = []
                     for each in args_list:
-                        args.append(settings[each])
+                        args.append(self.settings[each])
                     working[new] = multiprocessing.Process(target=process_new, args=args)
                     working[new].start()
                 else:
@@ -137,14 +142,14 @@ class MainInstallation():
             # This line is temporary, for debugging purposes.
             # eprint(f"Running Processes: {len(working)}\nProcesses to do: {len(processes_to_do) - len(working)}")
 
-    def sequental_install(self, processes_to_do, settings):
+    def sequental_install(self):
         """Install Drauger OS, but instead of the multi-threaded approach above, do everything sequentially"""
-        for each in processes_to_do:
+        for each in self.processes_to_do:
             process_new = getattr(MainInstallation, each, self)
             args_list = getfullargspec(process_new)[0]
             args = []
             for each in args_list:
-                args.append(settings[each])
+                args.append(self.settings[each])
             # Not sure if this works. Keep an eye on it.
             process_new(*args)
             __update__(point + offset)
@@ -646,14 +651,15 @@ def install(settings, distro):
     for each in range(len(processes_to_do) - 1, -1, -1):
         if processes_to_do[each][0] == "_":
             del processes_to_do[each]
+    installer = MainInstallation(processes_to_do, settings)
     if os.cpu_count() > 2:
         try:
-            MainInstallation(processes_to_do, settings)
+            installer.parallel_install()
         except ConnectionResetError:
             eprint("WARNING: IT APPEARS MULTI-THREADED INSTALLATION FAILED. REATTEMPTING SEQUENTIALLY...")
-            MainInstallation.sequental_install(processes_to_do, settings)
+            installer.sequental_install()
     else:
-        MainInstallation.sequental_install(processes_to_do, settings)
+        installer.sequental_install()
     handle_laptops(settings["USERNAME"])
     setup_lowlevel(settings["EFI"], settings["ROOT"], distro,
                    settings["COMPAT_MODE"], settings["UPDATES"])

--- a/usr/share/edamame/modules/master.py
+++ b/usr/share/edamame/modules/master.py
@@ -112,7 +112,10 @@ class MainInstallation():
             for each in to_del:
                 del working[each]
             # Second, check how many processes we have running against how many cores we have
-            if len(working) < os.cpu_count():
+            # The minus one here is to compensate for the master thread taking up a process.
+            # This does mean that dual-core CPUs will install the OS entirely sequentially, instead of in parallel,
+            # but it will also leave more resources so the computer does not push itself TOO hard.
+            if len(working) < (os.cpu_count() - 1):
                 # We have fewer processes than CPUs.
                 if len(processes_to_do) > len(working):
                     """

--- a/usr/share/edamame/modules/master.py
+++ b/usr/share/edamame/modules/master.py
@@ -72,15 +72,16 @@ class MainInstallation():
         """Basic setup process"""
         self.processes_to_do = processes_to_do
         self.settings = settings
+        self.offset = 39
+        ending = 51
+        self.iterator = round(ending / len(self.processes_to_do))
+        # We COULD set point equal to iterator, but we don't want the iterator
+        # to change, so re-doing the math is safer, albiet slower.
+        self.point = round(ending / len(self.processes_to_do))
 
     def parallel_install(self):
         """Install Drauger OS, using multi-processing. The idea is to get everything done as quick as possible."""
-        offset = 39
-        ending = 51
-        iterator = round(ending / len(self.processes_to_do))
-        # We COULD set point equal to iterator, but we don't want the iterator
-        # to change, so re-doing the math is safer, albiet slower.
-        point = round(ending / len(self.processes_to_do))
+
         # while len(processes_to_do) > 0:
         #     for each in range(len(processes_to_do) - 1, -1, -1):
         #         if not globals()[processes_to_do[each]].is_alive():
@@ -104,8 +105,8 @@ class MainInstallation():
                     working[each].join()
                     del self.processes_to_do[self.processes_to_do.index(each)]
                     to_del.append(each)
-                    __update__(point + offset)
-                    point += iterator
+                    __update__(self.point + self.offset)
+                    self.point += self.iterator
             for each in to_del:
                 del working[each]
             # Second, check how many processes we have running against how many cores we have
@@ -152,8 +153,8 @@ class MainInstallation():
                 args.append(self.settings[each])
             # Not sure if this works. Keep an eye on it.
             process_new(*args)
-            __update__(point + offset)
-            point += iterator
+            __update__(self.point + self.offset)
+            self.point += self.iterator
 
     def time_set(TIME_ZONE):
         """Set system time"""

--- a/usr/share/edamame/modules/set_wallpaper.py
+++ b/usr/share/edamame/modules/set_wallpaper.py
@@ -53,6 +53,8 @@ Not using Advanced Quick Install's Wallpaper functionality.""")
                 pass
             if "monitor0" not in screens:
                 screens.append("monitor0")
+
+            # move wallpaper file to ~/.config
             move("/user-data/" + each,
                  "/home/" + username + "/.config/" + each)
     if len(screens) == 0:


### PR DESCRIPTION
This PR mostly affects the `common` package, as it fixes a number of installation errors and other minor issues.

First: Edamame was not removing itself on the installed system properly due to an error in `settings.json`. This has been corrected.

Second: There was a bug with partitioning on BIOS systems due to a missing if statement that got added.

Third: During installation, we are sometimes getting a strange connection error from the `multiprocessing` library. In order to work around this, on systems with 1 or 2 cores, a new sequential installation code path will be used. On more powerful systems, while the parallel code path will be used, the main thread is now better accounted for in the load. Also, if the parallel installation crashes with that same error, Edamame will attempt to fall back to sequential installation.

Fourth and finally for bug fixes, the help argument had broken formatting that got fixed.

For feature improvements, Edamame and Quick Install now support carrying over Network settings with Netplan.

On the note of Quick Install, a full Quick Install specification is now available, so if others want to implement the same features, they can use the same file format and have interoperability.